### PR TITLE
This PR addresses duplicated comments issue in GetComments.

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"golang.org/x/oauth2"
-	//_ "github.com/joho/godotenv/autoload"
 )
 
 var Scopes = []string{
@@ -104,7 +103,9 @@ func (u *User) UserClient(token *oauth2.Token) *Client {
 
 	c.common.client = c
 	c.Account = (*AccountService)(&c.common)
-	c.Comment = (*CommentService)(&c.common)
+	// here we can't use service struct because we included `path` member in
+	// CommentService
+	c.Comment = &CommentService{client: c}
 	c.Collection = (*CollectionService)(&c.common)
 	c.Flair = (*FlairService)(&c.common)
 	c.Gold = (*GoldService)(&c.common)

--- a/test/main.go
+++ b/test/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 
@@ -35,9 +36,26 @@ func main() {
 
 	u.UpdateToken(token)
 
-	//path :=https://www.reddit.com/r/redditdev/comments/avvl7u/nodejs_snoowrap_usage_find_number_of_comment/"
-	var c *slashred.Client = u.UserClient(token)
+	c := u.UserClient(token)
 
-	c.Subreddit.UploadSrImg("astar0n", "assets/testlogo.png", "", "icon")
+	// FIXME(hmble): This link is archived a good example for test
+	// but somehow I couldn't get all comments from this thread. Maybe there is
+	// some edge cases that I need to consider. As of now IMO issue is getting
+	// parent article's more children array.
+	path := "https://www.reddit.com/r/learnprogramming/comments/bs6466/why_study_programming_when_you_can_just_play_an/"
+	comments := c.Comment.GetComments(path, "")
+
+	for _, comment := range comments {
+		fmt.Println("-----------------  ", comment.Author)
+		if len(comment.Body) < 50 {
+			fmt.Println(comment.Body)
+		} else {
+			fmt.Println(comment.Body[:50])
+		}
+
+		fmt.Println("-----------------")
+	}
+
+	fmt.Printf("Comments length is %d\n", len(comments))
 
 }


### PR DESCRIPTION
There are some API changes introduced in this PR which is more easy than previous API. Now theres no need to call two methods of `GetComments` and `List` to get full list of comments.

There are some edge cases which are not yet solved for some threads. I will cover those edge cases in next PR. This will help to keep commits simple.